### PR TITLE
Use 'remotes' instead of 'devtools'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package is currently under development.  Please raise issues for any bugs yo
 ## Installation
 
 ```
-library(devtools)
+library(remotes)
 install_github("drveera/ggman")
 ```
 


### PR DESCRIPTION
Hi @drveera, 

This is a tiny correction. Using `devtools` used to be the only way, yet `install_github` is migrating to `remotes`. Using `devtools::install_github` gives a warning message on this on newer versions of R.

Cheers, Richel